### PR TITLE
swap with xor trick

### DIFF
--- a/FastLED_GFX.h
+++ b/FastLED_GFX.h
@@ -18,7 +18,7 @@ date:      2016/04/27
 
 #include "gfxfont.h"
 
-#define adagfxswap(a, b) { int16_t t = a; a = b; b = t; }
+#define adagfxswap(a, b) { a = a ^ b; b = a ^ b; a = a ^ b; }
 
 #if !defined(ESP8266)
   #define swap(a, b) adagfxswap(a, b)


### PR DESCRIPTION
There is no need to use a temporary int16_t.

https://en.wikipedia.org/wiki/XOR_swap_algorithm